### PR TITLE
AppAPI 2.0.3+/AppStore changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,5 +46,5 @@ run:
 register:
 	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:unregister llm2 --silent || true
 	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:register llm2 manual_install --json-info \
-  "{\"appid\":\"llm2\",\"name\":\"Local large language model\",\"daemon_config_name\":\"manual_install\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"host\":\"host.docker.internal\",\"port\":9081,\"scopes\":{\"required\":[\"AI_PROVIDERS\"],\"optional\":[]},\"protocol\":\"http\",\"system_app\":0}" \
+  "{\"appid\":\"llm2\",\"name\":\"Local large language model\",\"daemon_config_name\":\"manual_install\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"port\":9081,\"scopes\":[\"AI_PROVIDERS\"],\"system_app\":0}" \
   --force-scopes --wait-finish

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -26,13 +26,8 @@
 			<image-tag>latest</image-tag>
 		</docker-install>
 		<scopes>
-			<required>
-				<value>AI_PROVIDERS</value>
-			</required>
-			<optional>
-			</optional>
+			<value>AI_PROVIDERS</value>
 		</scopes>
-		<protocol>http</protocol>
 		<system>false</system>
 	</external-app>
 </info>


### PR DESCRIPTION
Today new version of AppStore was deployed that ignores "protocol" field, and API scopes are now only "required" no more "optional" or "required" keys in info.xml

Let's make it simpler :)