### PR TITLE
build: Skip downloading exisiting models

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,10 @@ build-push:
 .PHONY: download-models
 download-models:
 	cd models && \
-	wget https://download.nextcloud.com/server/apps/llm/leo-hessianai-13B-chat-bilingual-GGUF/leo-hessianai-13b-chat-bilingual.Q4_K_M.gguf \
-	&& wget https://huggingface.co/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF/resolve/main/tinyllama-1.1b-chat-v1.0.Q4_0.gguf \
-	&& wget https://download.nextcloud.com/server/apps/llm/llama-2-7b-chat-ggml/llama-2-7b-chat.Q4_K_M.gguf \
-	&& wget https://huggingface.co/Nextcloud-AI/llm_neuralbeagle_14_7b_gguf/resolve/main/neuralbeagle14-7b.Q4_K_M.gguf
+	wget -nc https://download.nextcloud.com/server/apps/llm/leo-hessianai-13B-chat-bilingual-GGUF/leo-hessianai-13b-chat-bilingual.Q4_K_M.gguf \
+	&& wget -nc https://huggingface.co/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF/resolve/main/tinyllama-1.1b-chat-v1.0.Q4_0.gguf \
+	&& wget -nc https://download.nextcloud.com/server/apps/llm/llama-2-7b-chat-ggml/llama-2-7b-chat.Q4_K_M.gguf \
+	&& wget -nc https://huggingface.co/Nextcloud-AI/llm_neuralbeagle_14_7b_gguf/resolve/main/neuralbeagle14-7b.Q4_K_M.gguf
 
 .PHONY: run29
 run29:


### PR DESCRIPTION
Rerunning `make download-models` would download all models again and not overwrite the existing ones. Also makes it easier to download the models in case some are already downloaded and a new one was added as only the new one will have to be downloaded.