### PR TITLE
fix(chatwithtools): Try to prevent leaking prompt parts

### DIFF
--- a/lib/chatwithtools.py
+++ b/lib/chatwithtools.py
@@ -133,7 +133,11 @@ The following is a JSON specification of the tools you can call and their parame
                 for tool_message in tool_messages:
                     message_content = """
     The result of your tool call for the tool "{tool_name}" is the following:
+    
+    ===
     {tool_call_result}
+    ===
+    
     You can now formulate this in natural language for the user. Do not mention that you called a tool.
     """.format(tool_call_result=tool_message['content'], tool_name=tool_message['name'])
                     messages.append(HumanMessage(


### PR DESCRIPTION
Fixes this situation:

<img width="1511" height="303" alt="image" src="https://github.com/user-attachments/assets/8534be43-e111-4c22-ac95-d23b4c1c08c9" />
