### PR TITLE
ci(workflows): automatically generate Docker image on new app version release

### DIFF
--- a/.github/workflows/publish-docker-cpu.yml
+++ b/.github/workflows/publish-docker-cpu.yml
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+name: Publish CPU Image
+
+on:
+  push:
+    tags:
+      - v*
+  workflow_dispatch:
+
+permissions:
+  packages: write
+  contents: read
+
+jobs:
+  push_to_registry:
+    name: Build image
+    runs-on: ubuntu-22.04
+    if: ${{ github.repository_owner == 'nextcloud' }}
+    steps:
+      - name: Set app env
+        run: |
+          # Split and keep last
+          echo "APP_NAME=${GITHUB_REPOSITORY##*/}" >> $GITHUB_ENV
+          echo "APP_VERSION=${GITHUB_REF##*/}" >> $GITHUB_ENV
+
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+          path: ${{ env.APP_NAME }}
+
+      - name: Read package.json node and npm engines version
+        uses: skjnldsv/read-package-engines-version-actions@06d6baf7d8f41934ab630e97d9e6c0bc9c9ac5e4 # v3
+        id: versions
+        # Continue if no package.json
+        continue-on-error: true
+        with:
+          path: ${{ env.APP_NAME }}
+          fallbackNode: '^20'
+          fallbackNpm: '^10'
+
+      - name: Set up node ${{ steps.versions.outputs.nodeVersion }}
+        # Skip if no package.json
+        if: ${{ steps.versions.outputs.nodeVersion }}
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: ${{ steps.versions.outputs.nodeVersion }}
+
+      - name: Set up npm ${{ steps.versions.outputs.npmVersion }}
+        # Skip if no package.json
+        if: ${{ steps.versions.outputs.npmVersion }}
+        run: npm i -g 'npm@${{ steps.versions.outputs.npmVersion }}'
+
+      - name: Build ${{ env.APP_NAME }}
+        # Skip if no package.json
+        if: ${{ steps.versions.outputs.nodeVersion }}
+        env:
+          CYPRESS_INSTALL_BINARY: 0
+        run: |
+          cd ${{ env.APP_NAME }}
+          npm ci
+          npm run build --if-present
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Available platforms
+        run: echo ${{ steps.buildx.outputs.platforms }}
+
+      - name: Install xmlstarlet
+        run: sudo apt-get update && sudo apt-get install -y xmlstarlet
+
+      - name: Extract version from XML
+        id: extract_version
+        run: |
+          cd ${{ env.APP_NAME }}
+          VERSION=$(xmlstarlet sel -t -v "//image-tag" appinfo/info.xml)
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Log version
+        run: |
+          echo "Extracted version: ${{ env.VERSION }}"
+
+      - name: Build container image
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          push: true
+          context: ./${{ env.APP_NAME }}
+          platforms: linux/amd64
+          tags: |
+            ghcr.io/nextcloud/${{ env.APP_NAME }}:${{ env.VERSION }}
+            ghcr.io/nextcloud/${{ env.APP_NAME }}:latest
+          build-args: |
+            BUILD_TYPE=cpu


### PR DESCRIPTION
Removes the need to run `make build-push` manually after each release. Workflow is based on:

https://github.com/nextcloud/talk_bot_ai/blob/main/.github/workflows/publish-docker-cpu.yml

but here, the action is triggered on new tags instead of new releases, as the releases are in the nextcloud-releases org (separate from the project repo), whereas the talk_bot_ai app has the releases in the same repo.