### PR TITLE
chore: prepare 2.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.7.0] - 2026-04-13
+
+### Added
+
+- Kubernetes scaling support
+- Optional memories input for `core:text2text:chat` task
+- `TASK_POLLING_INTERVAL` environment variable
+
+### Changed
+
+- Bump max supported Nextcloud version to 34
+- Update dependencies
+
+### Fixed
+
+- Gracefully shutdown if SIGTERM is received
+
 ## [2.6.0] - 2025-12-09
 
 ### Added

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -13,7 +13,7 @@
 
 See [the nextcloud admin docs](https://docs.nextcloud.com/server/latest/admin_manual/ai/index.html) for more information.
 	]]></description>
-	<version>2.6.0</version>
+	<version>2.7.0</version>
 	<licence>MIT</licence>
 	<author mail="mklehr@gmx.net" homepage="https://github.com/marcelklehr">Marcel Klehr</author>
 	<author mail="bigcat88@icloud.com" homepage="https://github.com/bigcat88">Alexander Piskun</author>
@@ -30,7 +30,7 @@ See [the nextcloud admin docs](https://docs.nextcloud.com/server/latest/admin_ma
 		<docker-install>
 			<registry>ghcr.io</registry>
 			<image>nextcloud/llm2</image>
-			<image-tag>2.6.0</image-tag>
+			<image-tag>2.7.0</image-tag>
 		</docker-install>
 		<system>false</system>
 		<environment-variables>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -24,7 +24,7 @@ See [the nextcloud admin docs](https://docs.nextcloud.com/server/latest/admin_ma
 	<repository type="git">https://github.com/nextcloud/llm2</repository>
 	<screenshot>https://raw.githubusercontent.com/nextcloud/llm2/main/img/Logo.png</screenshot>
 	<dependencies>
-		<nextcloud min-version="30" max-version="33"/>
+		<nextcloud min-version="30" max-version="34"/>
 	</dependencies>
 	<external-app>
 		<docker-install>


### PR DESCRIPTION
### Added

- Kubernetes scaling support
- Optional memories input for `core:text2text:chat` task
- `TASK_POLLING_INTERVAL` environment variable

### Changed

- Bump max supported Nextcloud version to 34
- Update dependencies

### Fixed

- Gracefully shutdown if SIGTERM is received