### PR TITLE
feat: add Qwen3.5 (9B) as an included model

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,13 @@ See [the Nextcloud admin documentation](https://docs.nextcloud.com/server/latest
    Examples:
 
    ```sh
+   wget -nc -P models https://huggingface.co/unsloth/Qwen3.5-9B-GGUF/resolve/main/Qwen3.5-9B-Q4_K_M.gguf
    wget -nc -P models https://download.nextcloud.com/server/apps/llm/llama-2-7b-chat-ggml/llama-2-7b-chat.Q4_K_M.gguf
    wget -nc -P models https://download.nextcloud.com/server/apps/llm/leo-hessianai-13B-chat-bilingual-GGUF/leo-hessianai-13b-chat-bilingual.Q4_K_M.gguf
    wget -nc -P models https://huggingface.co/Nextcloud-AI/llm_neuralbeagle_14_7b_gguf/resolve/main/neuralbeagle14-7b.Q4_K_M.gguf
    ```
 
-4. Run the app:
+4. Run the app (replace `<APP_VERSION>` with the actual app version from `appinfo/info.xml`):
 
    ```sh
    PYTHONUNBUFFERED=1 APP_HOST=0.0.0.0 APP_ID=llm2 APP_PORT=9081 APP_SECRET=12345 APP_VERSION=<APP_VERSION> NEXTCLOUD_URL=http://nextcloud.local python3 lib/main.py

--- a/default_config/config.json
+++ b/default_config/config.json
@@ -58,6 +58,15 @@
             "temperature": 0.15
         }
     },
+    "Qwen3.5-9B-Q4_K_M": {
+        "prompt": "<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n{system_prompt}<|eot_id|><|start_header_id|>user<|end_header_id|>\n{user_prompt}<|eot_id|>\n<|start_header_id|>assistant<|end_header_id|>\n",
+        "loader_config": {
+            "n_ctx": 16384,
+            "max_tokens": 8192,
+            "stop": ["<|eot_id|>"],
+            "temperature": 0.7
+        }
+    },
     "olmo-2-1124-7B-instruct-Q4_K_M": {
         "prompt": "<|endoftext|><|system|>\n{system_prompt}\n<|user|>\n{system_prompt}\n{user_prompt}\n<|assistant|>\n",
         "loader_config": {

--- a/lib/main.py
+++ b/lib/main.py
@@ -34,6 +34,7 @@ def log(nc, level, content):
         pass
 
 models_to_fetch = {
+    "https://huggingface.co/unsloth/Qwen3.5-9B-GGUF/resolve/3885219b6810b007914f3a7950a8d1b469d598a5/Qwen3.5-9B-Q4_K_M.gguf": { "save_path": os.path.join(persistent_storage(), "Qwen3.5-9B-Q4_K_M.gguf") },
     "https://huggingface.co/bartowski/Meta-Llama-3.1-8B-Instruct-GGUF/resolve/4f0c246f125fc7594238ebe7beb1435a8335f519/Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf": { "save_path": os.path.join(persistent_storage(), "Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf") },
     "https://huggingface.co/unsloth/Olmo-3-7B-Instruct-GGUF/resolve/86844f8ff856ba9cc8a22c7b9edd7cf95129a580/Olmo-3-7B-Instruct-Q4_K_M.gguf": { "save_path": os.path.join(persistent_storage(), "Olmo-3-7B-Instruct-Q4_K_M.gguf") },
 }


### PR DESCRIPTION
Adds [Qwen3.5 (9B)](https://huggingface.co/unsloth/Qwen3.5-9B-GGUF) to the list of included models after a recent [community poll](https://help.nextcloud.com/t/what-are-your-favorite-open-source-ai-models-help-shape-the-future-of-local-ai-in-nextcloud/244127). Config parameters may still need to be tweaked, but Qwen's thinking capabilities are disabled by default on the small models (9B or less), so no other tweaks are necessary as of now.

Related: #177 

@marcelklehr Do you know how does the app decides which model is chosen as the default? Is it just the first one alphabetically?