### PR TITLE
chore: prepare 2.8.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.8.0] - 2026-07-15
+
+### Added
+
+- Streaming output (both text and tool calls)
+- Support for reformat paragraphs and improve text task types
+- Ship Qwen 3.5 (9B) and Gemma 4 (E4B) models
+- Reasoning output for compatible models
+- Docker builds for CUDA and ROCm
+- Task batching
+
+### Changed
+
+- Bump max supported Nextcloud version to 35
+- Adjust system prompts for several tasks
+- Update dependencies
+
 ## [2.7.0] - 2026-04-13
 
 ### Added

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -24,7 +24,7 @@ See [the nextcloud admin docs](https://docs.nextcloud.com/server/latest/admin_ma
 	<repository type="git">https://github.com/nextcloud/llm2</repository>
 	<screenshot>https://raw.githubusercontent.com/nextcloud/llm2/main/img/Logo.png</screenshot>
 	<dependencies>
-		<nextcloud min-version="30" max-version="34"/>
+		<nextcloud min-version="30" max-version="35"/>
 	</dependencies>
 	<external-app>
 		<docker-install>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -13,7 +13,7 @@
 
 See [the nextcloud admin docs](https://docs.nextcloud.com/server/latest/admin_manual/ai/index.html) for more information.
 	]]></description>
-	<version>2.7.0</version>
+	<version>2.8.0</version>
 	<licence>MIT</licence>
 	<author mail="mklehr@gmx.net" homepage="https://github.com/marcelklehr">Marcel Klehr</author>
 	<author mail="bigcat88@icloud.com" homepage="https://github.com/bigcat88">Alexander Piskun</author>
@@ -30,7 +30,7 @@ See [the nextcloud admin docs](https://docs.nextcloud.com/server/latest/admin_ma
 		<docker-install>
 			<registry>ghcr.io</registry>
 			<image>nextcloud/llm2</image>
-			<image-tag>2.7.0</image-tag>
+			<image-tag>2.8.0</image-tag>
 		</docker-install>
 		<system>false</system>
 		<environment-variables>


### PR DESCRIPTION
@marcelklehr Let me know if I missed anything in the changelog here.

### Added

- Streaming output (both text and tool calls)
- Support for reformat paragraphs and improve text task types
- Ship Qwen 3.5 (9B) and Gemma 4 (E4B) models
- Reasoning output for compatible models
- Docker builds for CUDA and ROCm
- Task batching

### Changed

- Bump max supported Nextcloud version to 35
- Adjust system prompts for several tasks
- Update dependencies